### PR TITLE
设置超时时间为60秒

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -154,7 +154,8 @@ class JimengApiClient {
         url,
         data: method.toUpperCase() !== 'GET' ? data : undefined,
         params: method.toUpperCase() === 'GET' ? { ...data, ...params } : params,
-        headers: requestHeaders
+        headers: requestHeaders,
+        timeout: 60000
       });
 
 


### PR DESCRIPTION
即梦创建图片过程较长，导致图片创建接口超时失败，但实际上接口是请求成功的，调整超时时间为60s